### PR TITLE
Add ``roman-numerals-py`` meta-package

### DIFF
--- a/python/roman-numerals-py/pyproject.toml
+++ b/python/roman-numerals-py/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "roman-numerals-py"
+description = "This package is deprecated, switch to roman-numerals."
+readme.text = """
+This package is deprecated, switch to `roman-numerals`__.
+
+__ https://pypi.org/project/roman-numerals/
+"""
+readme.content-type = "text/x-rst"
+version = "3.1.0"
+dependencies = [
+    "roman-numerals==3.1.0",
+]
+urls.Code = "https://github.com/AA-Turner/roman-numerals/"
+urls.Download = "https://pypi.org/project/roman-numerals-py/"
+license.text = "0BSD or CC0-1.0"
+requires-python = ">=3.9"
+
+[[project.authors]]
+name = "Adam Turner"


### PR DESCRIPTION
@jambonrose has kindly donated the [`roman-numerals`](https://pypi.org/project/roman-numerals/) package name on Python to this project. I have back-filled the current releases, but for the next release, we should begin to deprecate the old `roman-numerals-py` name. This PR adds a minimal project that depends on the new package name and can be uploaded as the next release of [`roman-numerals-py`](https://pypi.org/project/roman-numerals-py/).

A