### PR TITLE
Use PEP 639 license expression

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@
 # Use flit as a build backend (https://flit.pypa.io/)
 # Build with (https://build.pypa.io/)
 [build-system]
-requires = ["flit_core>=3.7,<4"]
+requires = ["flit_core>=3.12,<4"]
 build-backend = "flit_core.buildapi"
 
 # Project metadata
@@ -16,7 +16,7 @@ urls.Changelog = "https://github.com/AA-Turner/roman-numerals/blob/master/CHANGE
 urls.Code = "https://github.com/AA-Turner/roman-numerals/"
 urls.Download = "https://pypi.org/project/roman-numerals/"
 urls."Issue tracker" = "https://github.com/AA-Turner/roman-numerals/issues"
-license.file = "LICENCE.rst"
+license = "0BSD OR CC0-1.0"
 requires-python = ">=3.9"
 
 # Classifiers list: https://pypi.org/classifiers/
@@ -24,8 +24,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Zero-Clause BSD (0BSD)",
-    "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
This fixes build failure with the latest flit:

```
dmitry@l3:~/upstream/roman-numerals/python (master)$ python3 -m build
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - flit_core>=3.7,<4
* Getting build dependencies for sdist...
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    main()
    ~~~~^^
  File "/usr/lib/python3/dist-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
                             ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pyproject_hooks/_in_process/_in_process.py", line 317, in get_requires_for_build_sdist
    return hook(config_settings)
  File "/tmp/build-env-uspew5sx/lib/python3.13/site-packages/flit_core/buildapi.py", line 23, in get_requires_for_build_wheel
    info = read_flit_config(pyproj_toml)
  File "/tmp/build-env-uspew5sx/lib/python3.13/site-packages/flit_core/config.py", line 85, in read_flit_config
    return prep_toml_config(d, path)
  File "/tmp/build-env-uspew5sx/lib/python3.13/site-packages/flit_core/config.py", line 112, in prep_toml_config
    loaded_cfg = read_pep621_metadata(d['project'], path)
  File "/tmp/build-env-uspew5sx/lib/python3.13/site-packages/flit_core/config.py", line 618, in read_pep621_metadata
    raise ConfigError(f"License file {license_tbl['file']} does not exist")
flit_core.config.ConfigError: License file LICENCE.rst does not exist

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_sdist
```

The license classifiers are removed as they are [deprecated](https://peps.python.org/pep-0639/#deprecate-license-classifiers) by the same PEP.