### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -106,6 +106,7 @@ jobs:
       matrix:
         python:
         - "3.13"
+        - "3.14"
 
     steps:
     - uses: actions/checkout@v4
@@ -137,7 +138,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - "3.14"
+        - "3.15"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -36,11 +36,11 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - "3.9"
         - "3.10"
         - "3.11"
         - "3.12"
         - "3.13"
+        - "3.14"
 
     steps:
     - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - "3.14"
+        - "3.15"
 
     steps:
     - uses: actions/checkout@v4

--- a/python/.ruff.toml
+++ b/python/.ruff.toml
@@ -1,4 +1,4 @@
-target-version = "py39"  # Pin Ruff to Python 3.9
+target-version = "py310"  # Pin Ruff to Python 3.10
 line-length = 88
 output-format = "full"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@ urls.Code = "https://github.com/AA-Turner/roman-numerals/"
 urls.Download = "https://pypi.org/project/roman-numerals/"
 urls."Issue tracker" = "https://github.com/AA-Turner/roman-numerals/issues"
 license = "0BSD OR CC0-1.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 # Classifiers list: https://pypi.org/classifiers/
 classifiers = [
@@ -27,12 +27,12 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
 ]
 dependencies = []
 dynamic = ["version"]
@@ -63,7 +63,7 @@ files = [
     "roman_numerals",
     "tests",
 ]
-python_version = "3.9"
+python_version = "3.10"
 strict = true
 show_column_numbers = true
 show_error_context = true

--- a/python/roman-numerals-py/pyproject.toml
+++ b/python/roman-numerals-py/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 urls.Code = "https://github.com/AA-Turner/roman-numerals/"
 urls.Download = "https://pypi.org/project/roman-numerals-py/"
 license.text = "0BSD or CC0-1.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [[project.authors]]
 name = "Adam Turner"


### PR DESCRIPTION
Python 3.9 reached [end of life](https://peps.python.org/pep-0596/) on 31 October 2025.

A